### PR TITLE
added 1 to line number

### DIFF
--- a/TagListPlugin.scala
+++ b/TagListPlugin.scala
@@ -36,7 +36,7 @@ object TagListPlugin extends Plugin {
         (file, tags) <- tagList;
         (lineNumber, tagLine) <- tags
       ) {
-        streams.log.warn(file.getName + ":" + lineNumber + ": " + tagLine.trim)
+        streams.log.warn(file.getName + ":" + (lineNumber + 1) + ": " + tagLine.trim)
       }
 
       tagList


### PR DESCRIPTION
Line number is currently zero-indexed. Vi and Sublime Text start at 1, so the references are always off by one.
