### PR TITLE
Better cross-building and package namespace

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,9 @@ version := "1.3-SNAPSHOT"
 
 organization := "com.markatta"
 
-crossScalaVersions := Seq("2.9.2", "2.10.1")
+crossBuildingSettings
+
+CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")
 
 scalacOptions += "-unchecked"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
-addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.7.0-RC2")
+resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+
+addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.0")

--- a/src/main/scala/TagListPlugin.scala
+++ b/src/main/scala/TagListPlugin.scala
@@ -1,4 +1,5 @@
-import com.markatta.sbttaglist.{TextUtils, Trie}
+package com.markatta.sbttaglist
+
 import io.Source
 import sbt._
 import Keys._


### PR DESCRIPTION
Hi! Thanks for the great plugin. It's very useful!

I've just updated sbt-cross-building plugin version and added it's settings to the `build.sbt`. It seems that so far this plugin is not published for sbt-0.13, but I'd like to use it in my plugin based on sbt-0.13.

Also, there is one issue, when I try to use it in my plugin's code: I cannot refer to the stuff in `TagListPlugin` object if it doesn't have an explicit package namespace. So I added it (the same you use in other sources). Change it if you want it to be different.
